### PR TITLE
Add leading tilde to filename when setting user pam env data

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Set user pam env data
   lineinfile:
-    dest:   "{{ env_user_pam_filename }}"
+    dest:   "~/{{ env_user_pam_filename }}"
     regexp: "^{{ item }}="
     line:   "{{ item }}={{ env_user_pam_data[item] }}"
   with_items: "{{ env_user_pam_data }}"


### PR DESCRIPTION
This fixed an error I was getting (it said `.pam_environment` does not exist).